### PR TITLE
Add pyramid attention variants for SAKT and SAINT models

### DIFF
--- a/configs/kt_config.json
+++ b/configs/kt_config.json
@@ -43,6 +43,30 @@
         "dropout": 0.2,
         "n_blocks": 2
     },
+    "pam_sakt": {
+        "learning_rate": 1e-3,
+        "emb_size": 256,
+        "num_attn_heads": 8,
+        "dropout": 0.2,
+        "num_en": 1,
+        "num_pyramid_levels": 2
+    },
+    "pam_saint": {
+        "learning_rate": 1e-3,
+        "emb_size": 256,
+        "num_attn_heads": 8,
+        "dropout": 0.2,
+        "n_blocks": 2,
+        "num_pyramid_levels": 2
+    },
+    "pam_saint++": {
+        "learning_rate": 1e-3,
+        "emb_size": 256,
+        "num_attn_heads": 8,
+        "dropout": 0.2,
+        "n_blocks": 4,
+        "num_pyramid_levels": 2
+    },
     "akt": {
         "learning_rate": 1e-5,
         "d_model":256,

--- a/examples/wandb_pam_saint_plus_plus_train.py
+++ b/examples/wandb_pam_saint_plus_plus_train.py
@@ -1,0 +1,26 @@
+import argparse
+from wandb_train import main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_name", type=str, default="assist2015")
+    parser.add_argument("--model_name", type=str, default="pam_saint++")
+    parser.add_argument("--emb_type", type=str, default="qid")
+    parser.add_argument("--save_dir", type=str, default="saved_model")
+    # parser.add_argument("--learning_rate", type=float, default=1e-5)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--fold", type=int, default=0)
+    parser.add_argument("--dropout", type=float, default=0.2)
+
+    parser.add_argument("--emb_size", type=int, default=256)
+    parser.add_argument("--learning_rate", type=float, default=1e-3)
+    parser.add_argument("--num_attn_heads", type=int, default=8)
+    parser.add_argument("--n_blocks", type=int, default=4)
+    parser.add_argument("--num_pyramid_levels", type=int, default=2)
+    parser.add_argument("--use_wandb", type=int, default=1)
+    parser.add_argument("--add_uuid", type=int, default=1)
+
+    args = parser.parse_args()
+
+    params = vars(args)
+    main(params)

--- a/examples/wandb_pam_saint_train.py
+++ b/examples/wandb_pam_saint_train.py
@@ -1,0 +1,26 @@
+import argparse
+from wandb_train import main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_name", type=str, default="assist2015")
+    parser.add_argument("--model_name", type=str, default="pam_saint")
+    parser.add_argument("--emb_type", type=str, default="qid")
+    parser.add_argument("--save_dir", type=str, default="saved_model")
+    # parser.add_argument("--learning_rate", type=float, default=1e-5)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--fold", type=int, default=0)
+    parser.add_argument("--dropout", type=float, default=0.2)
+
+    parser.add_argument("--emb_size", type=int, default=256)
+    parser.add_argument("--learning_rate", type=float, default=1e-3)
+    parser.add_argument("--num_attn_heads", type=int, default=8)
+    parser.add_argument("--n_blocks", type=int, default=2)
+    parser.add_argument("--num_pyramid_levels", type=int, default=2)
+    parser.add_argument("--use_wandb", type=int, default=1)
+    parser.add_argument("--add_uuid", type=int, default=1)
+
+    args = parser.parse_args()
+
+    params = vars(args)
+    main(params)

--- a/examples/wandb_pam_sakt_train.py
+++ b/examples/wandb_pam_sakt_train.py
@@ -1,0 +1,26 @@
+import argparse
+from wandb_train import main
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset_name", type=str, default="assist2015")
+    parser.add_argument("--model_name", type=str, default="pam_sakt")
+    parser.add_argument("--emb_type", type=str, default="qid")
+    parser.add_argument("--save_dir", type=str, default="saved_model")
+    # parser.add_argument("--learning_rate", type=float, default=1e-5)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--fold", type=int, default=0)
+    parser.add_argument("--dropout", type=float, default=0.2)
+
+    parser.add_argument("--emb_size", type=int, default=256)
+    parser.add_argument("--learning_rate", type=float, default=1e-3)
+    parser.add_argument("--num_attn_heads", type=int, default=8)
+    parser.add_argument("--num_en", type=int, default=1)
+    parser.add_argument("--num_pyramid_levels", type=int, default=2)
+    parser.add_argument("--use_wandb", type=int, default=1)
+    parser.add_argument("--add_uuid", type=int, default=1)
+
+    args = parser.parse_args()
+
+    params = vars(args)
+    main(params)

--- a/examples/wandb_train.py
+++ b/examples/wandb_train.py
@@ -39,7 +39,7 @@ def main(params):
     with open("../configs/kt_config.json") as f:
         config = json.load(f)
         train_config = config["train_config"]
-        if model_name in ["dkvmn","deep_irt", "sakt", "saint","saint++", "akt", "robustkt", "folibikt", "atkt", "lpkt", "skvmn", "dimkt"]:
+        if model_name in ["dkvmn","deep_irt", "sakt", "pam_sakt", "saint","saint++", "pam_saint", "pam_saint++", "akt", "robustkt", "folibikt", "atkt", "lpkt", "skvmn", "dimkt"]:
             train_config["batch_size"] = 64 ## because of OOM
         if model_name in ["simplekt","stablekt", "datakt", "sparsekt"]:
             train_config["batch_size"] = 64 ## because of OOM
@@ -98,7 +98,7 @@ def main(params):
     for remove_item in ['use_wandb','learning_rate','add_uuid','l2']:
         if remove_item in model_config:
             del model_config[remove_item]
-    if model_name in ["saint","saint++", "sakt", "atdkt", "simplekt","stablekt", "datakt","folibikt"]:
+    if model_name in ["saint","saint++", "pam_saint", "pam_saint++", "sakt", "pam_sakt", "atdkt", "simplekt","stablekt", "datakt","folibikt"]:
         model_config["seq_len"] = seq_len
         
     debug_print(text = "init_model",fuc_name="main")

--- a/pykt/models/init_model.py
+++ b/pykt/models/init_model.py
@@ -8,6 +8,9 @@ from .dkvmn import DKVMN
 from .deep_irt import DeepIRT
 from .sakt import SAKT
 from .saint import SAINT
+from .pam_sakt import PAM_SAKT
+from .pam_saint import PAM_SAINT
+from .pam_saint_plus_plus import PAM_SAINT_PLUS_PLUS
 from .kqn import KQN
 from .atkt import ATKT
 from .dkt_forget import DKTForget
@@ -51,8 +54,14 @@ def init_model(model_name, model_config, data_config, emb_type):
         model = DeepIRT(data_config["num_c"], **model_config, emb_type=emb_type, emb_path=data_config["emb_path"]).to(device)
     elif model_name == "sakt":
         model = SAKT(data_config["num_c"],  **model_config, emb_type=emb_type, emb_path=data_config["emb_path"]).to(device)
+    elif model_name == "pam_sakt":
+        model = PAM_SAKT(data_config["num_c"], **model_config, emb_type=emb_type, emb_path=data_config["emb_path"]).to(device)
     elif model_name == "saint":
         model = SAINT(data_config["num_q"], data_config["num_c"], **model_config, emb_type=emb_type, emb_path=data_config["emb_path"]).to(device)
+    elif model_name == "pam_saint":
+        model = PAM_SAINT(data_config["num_q"], data_config["num_c"], **model_config, emb_type=emb_type, emb_path=data_config["emb_path"]).to(device)
+    elif model_name == "pam_saint++":
+        model = PAM_SAINT_PLUS_PLUS(data_config["num_q"], data_config["num_c"], **model_config, emb_type=emb_type, emb_path=data_config["emb_path"]).to(device)
     elif model_name == "dkt_forget":
         model = DKTForget(data_config["num_c"], data_config["num_rgap"], data_config["num_sgap"], data_config["num_pcount"], **model_config).to(device)
     elif model_name == "akt":

--- a/pykt/models/pam_saint.py
+++ b/pykt/models/pam_saint.py
@@ -1,0 +1,238 @@
+import torch
+import torch.nn as nn
+from torch.nn import Dropout
+import pandas as pd
+
+from .pyramid_attention import PyramidAttention
+from .utils import transformer_FFN, get_clones, ut_mask, pos_encode
+from torch.nn import Embedding, Linear
+
+
+device = "cpu" if not torch.cuda.is_available() else "cuda"
+
+
+class PAM_SAINT(nn.Module):
+    def __init__(
+        self,
+        num_q,
+        num_c,
+        seq_len,
+        emb_size,
+        num_attn_heads,
+        dropout,
+        n_blocks=1,
+        num_pyramid_levels=2,
+        emb_type="qid",
+        emb_path="",
+        pretrain_dim=768,
+    ):
+        super().__init__()
+        if num_q == num_c and num_q == 0:
+            assert num_q != 0
+        self.num_q = num_q
+        self.num_c = num_c
+        self.model_name = "pam_saint"
+        self.num_en = n_blocks
+        self.num_de = n_blocks
+        self.emb_type = emb_type
+
+        self.embd_pos = nn.Embedding(seq_len, embedding_dim=emb_size)
+
+        if emb_type.startswith("qid"):
+            encoder_block = Encoder_block(
+                emb_size,
+                num_attn_heads,
+                num_q,
+                num_c,
+                seq_len,
+                dropout,
+                num_pyramid_levels,
+                emb_path=emb_path,
+                pretrain_dim=pretrain_dim,
+            )
+            self.encoder = get_clones(encoder_block, self.num_en)
+
+        decoder_block = Decoder_block(
+            emb_size,
+            2,
+            num_attn_heads,
+            seq_len,
+            dropout,
+            num_pyramid_levels,
+        )
+        self.decoder = get_clones(decoder_block, self.num_de)
+
+        self.dropout = Dropout(dropout)
+        self.out = nn.Linear(in_features=emb_size, out_features=1)
+
+    def forward(self, in_ex, in_cat, in_res, qtest=False):
+        emb_type = self.emb_type
+
+        if self.num_q > 0:
+            in_pos = pos_encode(in_ex.shape[1])
+        else:
+            in_pos = pos_encode(in_cat.shape[1])
+        in_pos = self.embd_pos(in_pos)
+
+        first_block = True
+        for i in range(self.num_en):
+            if i >= 1:
+                first_block = False
+            if emb_type == "qid":
+                in_ex = self.encoder[i](in_ex, in_cat, in_pos, first_block=first_block)
+            in_cat = in_ex
+
+        start_token = torch.tensor([[2]]).repeat(in_res.shape[0], 1).to(device)
+        in_res = torch.cat((start_token, in_res), dim=-1)
+        first_block = True
+        for i in range(self.num_de):
+            if i >= 1:
+                first_block = False
+            in_res = self.decoder[i](in_res, in_pos, en_out=in_ex, first_block=first_block)
+
+        res = self.out(self.dropout(in_res))
+        res = torch.sigmoid(res).squeeze(-1)
+        if not qtest:
+            return res
+        else:
+            return res, in_res
+
+
+class Encoder_block(nn.Module):
+    def __init__(
+        self,
+        dim_model,
+        heads_en,
+        total_ex,
+        total_cat,
+        seq_len,
+        dropout,
+        num_pyramid_levels,
+        emb_path="",
+        pretrain_dim=768,
+    ):
+        super().__init__()
+        self.seq_len = seq_len
+        self.emb_path = emb_path
+        self.total_cat = total_cat
+        self.total_ex = total_ex
+        self.num_pyramid_levels = num_pyramid_levels
+        if total_ex > 0:
+            if emb_path == "":
+                self.embd_ex = nn.Embedding(total_ex, embedding_dim=dim_model)
+            else:
+                embs = pd.read_pickle(emb_path)
+                self.exercise_embed = Embedding.from_pretrained(embs)
+                self.linear = Linear(pretrain_dim, dim_model)
+        if total_cat > 0:
+            self.emb_cat = nn.Embedding(total_cat, embedding_dim=dim_model)
+
+        self.multi_en = PyramidAttention(
+            embed_dim=dim_model,
+            num_heads=heads_en,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.layer_norm1 = nn.LayerNorm(dim_model)
+        self.dropout1 = Dropout(dropout)
+
+        self.ffn_en = transformer_FFN(dim_model, dropout)
+        self.layer_norm2 = nn.LayerNorm(dim_model)
+        self.dropout2 = Dropout(dropout)
+
+    def forward(self, in_ex, in_cat, in_pos, first_block=True):
+        if first_block:
+            embs = []
+            if self.total_ex > 0:
+                if self.emb_path == "":
+                    in_ex = self.embd_ex(in_ex)
+                else:
+                    in_ex = self.linear(self.exercise_embed(in_ex))
+                embs.append(in_ex)
+            if self.total_cat > 0:
+                in_cat = self.emb_cat(in_cat)
+                embs.append(in_cat)
+            out = embs[0]
+            for i in range(1, len(embs)):
+                out += embs[i]
+            out = out + in_pos
+        else:
+            out = in_ex
+
+        out = out.permute(1, 0, 2)
+        n, _, _ = out.shape
+        out = self.layer_norm1(out)
+        skip_out = out
+        out, _ = self.multi_en(out, out, out, attn_mask=ut_mask(seq_len=n))
+        out = self.dropout1(out)
+        out = out + skip_out
+
+        out = out.permute(1, 0, 2)
+        out = self.layer_norm2(out)
+        skip_out = out
+        out = self.ffn_en(out)
+        out = self.dropout2(out)
+        out = out + skip_out
+
+        return out
+
+
+class Decoder_block(nn.Module):
+    def __init__(self, dim_model, total_res, heads_de, seq_len, dropout, num_pyramid_levels):
+        super().__init__()
+        self.seq_len = seq_len
+        self.embd_res = nn.Embedding(total_res + 1, embedding_dim=dim_model)
+
+        self.multi_de1 = PyramidAttention(
+            embed_dim=dim_model,
+            num_heads=heads_de,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.multi_de2 = PyramidAttention(
+            embed_dim=dim_model,
+            num_heads=heads_de,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.ffn_en = transformer_FFN(dim_model, dropout)
+
+        self.layer_norm1 = nn.LayerNorm(dim_model)
+        self.layer_norm2 = nn.LayerNorm(dim_model)
+        self.layer_norm3 = nn.LayerNorm(dim_model)
+
+        self.dropout1 = Dropout(dropout)
+        self.dropout2 = Dropout(dropout)
+        self.dropout3 = Dropout(dropout)
+
+    def forward(self, in_res, in_pos, en_out, first_block=True):
+        if first_block:
+            in_in = self.embd_res(in_res)
+            out = in_in + in_pos
+        else:
+            out = in_res
+
+        out = out.permute(1, 0, 2)
+        n, _, _ = out.shape
+
+        out = self.layer_norm1(out)
+        skip_out = out
+        out, _ = self.multi_de1(out, out, out, attn_mask=ut_mask(seq_len=n))
+        out = self.dropout1(out)
+        out = skip_out + out
+
+        en_out = en_out.permute(1, 0, 2)
+        en_out = self.layer_norm2(en_out)
+        skip_out = out
+        out, _ = self.multi_de2(out, en_out, en_out, attn_mask=ut_mask(seq_len=n))
+        out = self.dropout2(out)
+        out = out + skip_out
+
+        out = out.permute(1, 0, 2)
+        out = self.layer_norm3(out)
+        skip_out = out
+        out = self.ffn_en(out)
+        out = self.dropout3(out)
+        out = out + skip_out
+
+        return out

--- a/pykt/models/pam_saint_plus_plus.py
+++ b/pykt/models/pam_saint_plus_plus.py
@@ -1,0 +1,259 @@
+import torch
+import torch.nn as nn
+from torch.nn import Dropout
+import pandas as pd
+
+from .pyramid_attention import PyramidAttention
+from .utils import transformer_FFN, get_clones, ut_mask, pos_encode
+from torch.nn import Embedding, Linear
+
+
+device = "cpu" if not torch.cuda.is_available() else "cuda"
+
+
+class PAM_SAINT_PLUS_PLUS(nn.Module):
+    def __init__(
+        self,
+        num_q,
+        num_c,
+        seq_len,
+        emb_size,
+        num_attn_heads,
+        dropout,
+        n_blocks=1,
+        num_pyramid_levels=2,
+        emb_type="qid",
+        emb_path="",
+        pretrain_dim=768,
+    ):
+        super().__init__()
+        if num_q == num_c and num_q == 0:
+            assert num_q != 0
+        self.num_q = num_q
+        self.num_c = num_c
+        self.model_name = "pam_saint++"
+        self.num_en = n_blocks
+        self.num_de = n_blocks
+        self.emb_type = emb_type
+
+        self.embd_pos = nn.Embedding(seq_len, embedding_dim=emb_size)
+
+        if emb_type.startswith("qid"):
+            encoder_block = Encoder_block(
+                emb_size,
+                num_attn_heads,
+                num_q,
+                num_c,
+                seq_len,
+                dropout,
+                num_pyramid_levels,
+                emb_path=emb_path,
+                pretrain_dim=pretrain_dim,
+            )
+            self.encoder = get_clones(encoder_block, self.num_en)
+
+        decoder_block = Decoder_block(
+            emb_size,
+            2,
+            num_attn_heads,
+            seq_len,
+            dropout,
+            num_q,
+            num_c,
+            num_pyramid_levels,
+        )
+        self.decoder = get_clones(decoder_block, self.num_de)
+
+        self.dropout = Dropout(dropout)
+        self.out = nn.Linear(in_features=emb_size, out_features=1)
+
+    def forward(self, in_ex, in_cat, in_res, qtest=False):
+        raw_in_ex = in_ex
+        raw_in_cat = in_cat
+        emb_type = self.emb_type
+
+        if self.num_q > 0:
+            in_pos = pos_encode(in_ex.shape[1])
+        else:
+            in_pos = pos_encode(in_cat.shape[1])
+        in_pos = self.embd_pos(in_pos)
+
+        first_block = True
+        for i in range(self.num_en):
+            if i >= 1:
+                first_block = False
+            if emb_type == "qid":
+                in_ex = self.encoder[i](in_ex, in_cat, in_pos, first_block=first_block)
+            in_cat = in_ex
+
+        start_token = torch.tensor([[0]]).repeat(in_res.shape[0], 1).to(device)
+        in_res = torch.cat((start_token, in_res), dim=-1)
+
+        first_block = True
+        for i in range(self.num_de):
+            if i >= 1:
+                first_block = False
+            in_res = self.decoder[i](raw_in_ex, raw_in_cat, in_res, in_pos, en_out=in_ex, first_block=first_block)
+
+        res = self.out(self.dropout(in_res))
+        res = torch.sigmoid(res).squeeze(-1)
+        if not qtest:
+            return res
+        else:
+            return res, in_res
+
+
+class Encoder_block(nn.Module):
+    def __init__(
+        self,
+        dim_model,
+        heads_en,
+        total_ex,
+        total_cat,
+        seq_len,
+        dropout,
+        num_pyramid_levels,
+        emb_path="",
+        pretrain_dim=768,
+    ):
+        super().__init__()
+        self.seq_len = seq_len
+        self.emb_path = emb_path
+        self.total_cat = total_cat
+        self.total_ex = total_ex
+        if total_ex > 0:
+            if emb_path == "":
+                self.embd_ex = nn.Embedding(total_ex, embedding_dim=dim_model)
+            else:
+                embs = pd.read_pickle(emb_path)
+                self.exercise_embed = Embedding.from_pretrained(embs)
+                self.linear = Linear(pretrain_dim, dim_model)
+
+        if total_cat > 0:
+            self.emb_cat = nn.Embedding(total_cat, embedding_dim=dim_model)
+
+        self.multi_en = PyramidAttention(
+            embed_dim=dim_model,
+            num_heads=heads_en,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.layer_norm1 = nn.LayerNorm(dim_model)
+        self.dropout1 = Dropout(dropout)
+
+        self.ffn_en = transformer_FFN(dim_model, dropout)
+        self.layer_norm2 = nn.LayerNorm(dim_model)
+        self.dropout2 = Dropout(dropout)
+
+    def forward(self, in_ex, in_cat, in_pos, first_block=True):
+        if first_block:
+            embs = []
+            if self.total_ex > 0:
+                if self.emb_path == "":
+                    in_ex = self.embd_ex(in_ex)
+                else:
+                    in_ex = self.linear(self.exercise_embed(in_ex))
+                embs.append(in_ex)
+            if self.total_cat > 0:
+                in_cat = self.emb_cat(in_cat)
+                embs.append(in_cat)
+            out = embs[0]
+            for i in range(1, len(embs)):
+                out += embs[i]
+            out = out + in_pos
+        else:
+            out = in_ex
+
+        out = out.permute(1, 0, 2)
+        n, _, _ = out.shape
+        out = self.layer_norm1(out)
+        skip_out = out
+        out, _ = self.multi_en(out, out, out, attn_mask=ut_mask(seq_len=n))
+        out = self.dropout1(out)
+        out = out + skip_out
+
+        out = out.permute(1, 0, 2)
+        out = self.layer_norm2(out)
+        skip_out = out
+        out = self.ffn_en(out)
+        out = self.dropout2(out)
+        out = out + skip_out
+
+        return out
+
+
+class Decoder_block(nn.Module):
+    def __init__(
+        self,
+        dim_model,
+        total_res,
+        heads_de,
+        seq_len,
+        dropout,
+        num_q,
+        num_c,
+        num_pyramid_levels,
+    ):
+        super().__init__()
+        self.seq_len = seq_len
+        self.num_q = num_q
+        self.num_c = num_c
+        self.embd_res = nn.Embedding(total_res + 1, embedding_dim=dim_model)
+        self.embd_ex = nn.Embedding(num_q * 2 + 1, embedding_dim=dim_model)
+        self.emb_cat = nn.Embedding(num_c * 2 + 1, embedding_dim=dim_model)
+
+        self.multi_de1 = PyramidAttention(
+            embed_dim=dim_model,
+            num_heads=heads_de,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.multi_de2 = PyramidAttention(
+            embed_dim=dim_model,
+            num_heads=heads_de,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.ffn_en = transformer_FFN(dim_model, dropout)
+
+        self.layer_norm1 = nn.LayerNorm(dim_model)
+        self.layer_norm2 = nn.LayerNorm(dim_model)
+        self.layer_norm3 = nn.LayerNorm(dim_model)
+
+        self.dropout1 = Dropout(dropout)
+        self.dropout2 = Dropout(dropout)
+        self.dropout3 = Dropout(dropout)
+
+    def forward(self, in_ex, in_cat, in_res, in_pos, en_out, first_block=True):
+        if first_block:
+            in_in = self.embd_res(in_res)
+            que_emb = self.embd_ex(in_ex + self.num_q * in_res)
+            cat_emb = self.emb_cat(in_cat + self.num_c * in_res)
+            out = in_in + que_emb + cat_emb + in_pos
+        else:
+            out = in_res
+
+        out = out.permute(1, 0, 2)
+        n, _, _ = out.shape
+
+        out = self.layer_norm1(out)
+        skip_out = out
+        out, _ = self.multi_de1(out, out, out, attn_mask=ut_mask(seq_len=n))
+        out = self.dropout1(out)
+        out = skip_out + out
+
+        en_out = en_out.permute(1, 0, 2)
+        en_out = self.layer_norm2(en_out)
+        skip_out = out
+        out, _ = self.multi_de2(out, en_out, en_out, attn_mask=ut_mask(seq_len=n))
+        out = self.dropout2(out)
+        out = out + skip_out
+
+        out = out.permute(1, 0, 2)
+        out = self.layer_norm3(out)
+        skip_out = out
+        out = self.ffn_en(out)
+        out = self.dropout3(out)
+        out = out + skip_out
+
+        return out

--- a/pykt/models/pam_sakt.py
+++ b/pykt/models/pam_sakt.py
@@ -1,0 +1,101 @@
+import torch
+
+from torch.nn import Module, Embedding, Linear, LayerNorm, Dropout
+
+from .pyramid_attention import PyramidAttention
+from .utils import transformer_FFN, pos_encode, ut_mask, get_clones
+
+
+class PAM_SAKT(Module):
+    def __init__(
+        self,
+        num_c,
+        seq_len,
+        emb_size,
+        num_attn_heads,
+        dropout,
+        num_en=2,
+        num_pyramid_levels=2,
+        emb_type="qid",
+        emb_path="",
+        pretrain_dim=768,
+    ):
+        super().__init__()
+        self.model_name = "pam_sakt"
+        self.emb_type = emb_type
+
+        self.num_c = num_c
+        self.seq_len = seq_len
+        self.emb_size = emb_size
+        self.num_attn_heads = num_attn_heads
+        self.dropout = dropout
+        self.num_en = num_en
+
+        if emb_type.startswith("qid"):
+            self.interaction_emb = Embedding(num_c * 2, emb_size)
+            self.exercise_emb = Embedding(num_c, emb_size)
+        self.position_emb = Embedding(seq_len, emb_size)
+
+        block = Blocks(emb_size, num_attn_heads, dropout, num_pyramid_levels)
+        self.blocks = get_clones(block, self.num_en)
+
+        self.dropout_layer = Dropout(dropout)
+        self.pred = Linear(self.emb_size, 1)
+
+    def base_emb(self, q, r, qry):
+        x = q + self.num_c * r
+        qshftemb = self.exercise_emb(qry)
+        xemb = self.interaction_emb(x)
+
+        posemb = self.position_emb(pos_encode(xemb.shape[1]))
+        xemb = xemb + posemb
+        return qshftemb, xemb
+
+    def forward(self, q, r, qry, qtest=False):
+        emb_type = self.emb_type
+        if emb_type == "qid":
+            qshftemb, xemb = self.base_emb(q, r, qry)
+        else:
+            raise NotImplementedError("PAM_SAKT currently supports emb_type='qid' only")
+
+        for i in range(self.num_en):
+            xemb = self.blocks[i](qshftemb, xemb, xemb)
+
+        p = torch.sigmoid(self.pred(self.dropout_layer(xemb))).squeeze(-1)
+        if not qtest:
+            return p
+        else:
+            return p, xemb
+
+
+class Blocks(Module):
+    def __init__(self, emb_size, num_attn_heads, dropout, num_pyramid_levels) -> None:
+        super().__init__()
+
+        self.attn = PyramidAttention(
+            emb_size,
+            num_attn_heads,
+            dropout=dropout,
+            num_levels=num_pyramid_levels,
+        )
+        self.attn_dropout = Dropout(dropout)
+        self.attn_layer_norm = LayerNorm(emb_size)
+
+        self.FFN = transformer_FFN(emb_size, dropout)
+        self.FFN_dropout = Dropout(dropout)
+        self.FFN_layer_norm = LayerNorm(emb_size)
+
+    def forward(self, q=None, k=None, v=None):
+        q, k, v = q.permute(1, 0, 2), k.permute(1, 0, 2), v.permute(1, 0, 2)
+        causal_mask = ut_mask(seq_len=k.shape[0])
+        attn_emb, _ = self.attn(q, k, v, attn_mask=causal_mask)
+
+        attn_emb = self.attn_dropout(attn_emb)
+        attn_emb, q = attn_emb.permute(1, 0, 2), q.permute(1, 0, 2)
+
+        attn_emb = self.attn_layer_norm(q + attn_emb)
+
+        emb = self.FFN(attn_emb)
+        emb = self.FFN_dropout(emb)
+        emb = self.FFN_layer_norm(attn_emb + emb)
+        return emb

--- a/pykt/models/pyramid_attention.py
+++ b/pykt/models/pyramid_attention.py
@@ -1,0 +1,108 @@
+import math
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class PyramidAttention(nn.Module):
+    """Multi-head attention with simple pyramid down-sampling.
+
+    The module computes attention outputs at multiple temporal resolutions and
+    blends them with learnable weights. Each resolution reuses a standard
+    ``nn.MultiheadAttention`` layer while keys/values are progressively
+    down-sampled through average pooling. Outputs from all resolutions are
+    combined through a learnable weighted sum followed by a projection layer.
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float = 0.0,
+        num_levels: int = 2,
+    ) -> None:
+        super().__init__()
+        if num_levels < 1:
+            raise ValueError("num_levels must be >= 1")
+        self.embed_dim = embed_dim
+        self.num_levels = num_levels
+        self.attn_layers = nn.ModuleList(
+            [nn.MultiheadAttention(embed_dim, num_heads, dropout=dropout) for _ in range(num_levels)]
+        )
+        self.level_weights = nn.Parameter(torch.ones(num_levels))
+        self.output_proj = nn.Linear(embed_dim, embed_dim)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        attn_mask: Optional[torch.Tensor] = None,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        need_weights: bool = False,
+        average_attn_weights: bool = True,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        outputs = []
+        weights_list = []
+        level_importance = torch.softmax(self.level_weights, dim=0)
+        for level, attn in enumerate(self.attn_layers):
+            key_level = self._downsample_sequence(key, level)
+            value_level = self._downsample_sequence(value, level)
+            attn_mask_level = self._downsample_attn_mask(attn_mask, level)
+            padding_mask_level = self._downsample_padding_mask(key_padding_mask, level)
+            out, attn_weights = attn(
+                query,
+                key_level,
+                value_level,
+                attn_mask=attn_mask_level,
+                key_padding_mask=padding_mask_level,
+                need_weights=need_weights,
+                average_attn_weights=average_attn_weights,
+            )
+            outputs.append(out)
+            if need_weights:
+                weights_list.append(attn_weights)
+        combined = sum(w * o for w, o in zip(level_importance, outputs))
+        combined = self.output_proj(combined)
+        combined = self.dropout(combined)
+        if need_weights:
+            stacked = torch.stack(weights_list)
+            level_importance = level_importance.view(-1, *([1] * (stacked.dim() - 1)))
+            attn_weights = (stacked * level_importance).sum(dim=0)
+        else:
+            attn_weights = None
+        return combined, attn_weights
+
+    def _downsample_sequence(self, tensor: torch.Tensor, level: int) -> torch.Tensor:
+        if level == 0:
+            return tensor
+        scale = 2 ** level
+        tensor_batched = tensor.permute(1, 2, 0)
+        pooled = F.avg_pool1d(tensor_batched, kernel_size=scale, stride=scale, ceil_mode=True)
+        return pooled.permute(2, 0, 1)
+
+    def _downsample_attn_mask(self, mask: Optional[torch.Tensor], level: int) -> Optional[torch.Tensor]:
+        if mask is None or level == 0:
+            return mask
+        scale = 2 ** level
+        seq_q, seq_k = mask.shape
+        new_seq_k = math.ceil(seq_k / scale)
+        pad_cols = new_seq_k * scale - seq_k
+        if pad_cols > 0:
+            pad_values = torch.ones(seq_q, pad_cols, dtype=mask.dtype, device=mask.device)
+            mask = torch.cat([mask, pad_values], dim=1)
+        mask = mask.view(seq_q, new_seq_k, scale)
+        mask = mask.any(dim=-1)
+        return mask
+
+    def _downsample_padding_mask(
+        self, mask: Optional[torch.Tensor], level: int
+    ) -> Optional[torch.Tensor]:
+        if mask is None or level == 0:
+            return mask
+        scale = 2 ** level
+        pooled = F.max_pool1d(mask.unsqueeze(1).float(), kernel_size=scale, stride=scale, ceil_mode=True)
+        return pooled.squeeze(1) > 0.5

--- a/pykt/models/train_model.py
+++ b/pykt/models/train_model.py
@@ -13,6 +13,9 @@ import pandas as pd
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
+SAKT_FAMILY = {"sakt", "pam_sakt"}
+SAINT_FAMILY = {"saint", "saint++", "pam_saint", "pam_saint++"}
+
 def cal_loss(model, ys, r, rshft, sm, preloss=[]):
     model_name = model.model_name
 
@@ -47,7 +50,7 @@ def cal_loss(model, ys, r, rshft, sm, preloss=[]):
             loss1 = loss1 + model.cl_weight * loss2
         loss =loss1
 
-    elif model_name in ["rkt","dimkt","dkt", "dkt_forget", "dkvmn","deep_irt", "kqn", "sakt", "saint", "atkt", "atktfix", "gkt", "skvmn", "hawkes"]:
+    elif model_name in ["rkt","dimkt","dkt", "dkt_forget", "dkvmn","deep_irt", "kqn", "sakt", "pam_sakt", "saint", "saint++", "pam_saint", "pam_saint++", "atkt", "atktfix", "gkt", "skvmn", "hawkes"]:
 
         y = torch.masked_select(ys[0], sm)
         t = torch.masked_select(rshft, sm)
@@ -211,10 +214,10 @@ def model_forward(model, data, rel=None):
     elif model_name in ["dkvmn","deep_irt", "skvmn"]:
         y = model(cc.long(), cr.long())
         ys.append(y[:,1:])
-    elif model_name in ["kqn", "sakt"]:
+    elif model_name in ["kqn"] or model_name in SAKT_FAMILY:
         y = model(c.long(), r.long(), cshft.long())
         ys.append(y)
-    elif model_name in ["saint"]:
+    elif model_name in SAINT_FAMILY:
         y = model(cq.long(), cc.long(), r.long())
         ys.append(y[:, 1:])
     elif model_name in ["akt","extrakt","folibikt", "robustkt", "akt_vector", "akt_norasch", "akt_mono", "akt_attn", "aktattn_pos", "aktmono_pos", "akt_raschx", "akt_raschy", "aktvec_raschx", "lefokt_akt", "fluckt"]:               


### PR DESCRIPTION
## Summary
- add a reusable PyramidAttention module for multi-scale attention pooling
- introduce PAM_SAKT, PAM_SAINT, and PAM_SAINT_PLUS_PLUS models that wrap the new attention module
- register the PAM models in configuration, initialization, and training/evaluation workflows
- add dedicated wandb launch scripts for the PAM attention variants

## Testing
- python -m compileall pykt/models
- python -m compileall examples/wandb_pam_sakt_train.py examples/wandb_pam_saint_train.py examples/wandb_pam_saint_plus_plus_train.py

------
https://chatgpt.com/codex/tasks/task_b_68cd04a921508325b442f14241bc3ab0